### PR TITLE
fixed issue with newer IOS devices causing an error.

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -36,8 +36,8 @@ const browserIDMap: { [id: string]: BrowserID } = {
  */
 export function detectBrowser(ua: string): Browser {
   const bowserInst = Bowser.getParser(ua);
-  let version = bowserInst.getBrowserVersion().toString();
   let bid: BrowserID = "unknown";
+  let version = (bowserInst.getBrowserVersion() || '').toString();
   for (const b in browserIDMap) {
     if (bowserInst.getBrowserName().toLowerCase() === b) {
       bid = browserIDMap[b];

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -37,7 +37,7 @@ const browserIDMap: { [id: string]: BrowserID } = {
 export function detectBrowser(ua: string): Browser {
   const bowserInst = Bowser.getParser(ua);
   let bid: BrowserID = "unknown";
-  let version = (bowserInst.getBrowserVersion() || '').toString();
+  let version = (bowserInst.getBrowserVersion() || "").toString();
   for (const b in browserIDMap) {
     if (bowserInst.getBrowserName().toLowerCase() === b) {
       bid = browserIDMap[b];

--- a/test/fixture.ts
+++ b/test/fixture.ts
@@ -113,6 +113,14 @@ const fixture: any = {
       flexbox: { level: "full", needPrefix: true, notes: [] },
     },
   },
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148": {
+    browser: { id: "ios_saf", version: "12.2" },
+    versionIndex: "12.2-12.3",
+    features: {
+      transforms2d: { level: "full", needPrefix: false, notes: [] },
+      flexbox: { level: "full", needPrefix: false, notes: [] },
+    },
+  },
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2": {
     browser: { id: "safari", version: "5.1.7" },
     versionIndex: "5.1",


### PR DESCRIPTION
Steps to reproduce:
```js
const { detectBrowser } = require('caniuse-support');
detectBrowser('Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148');
```
results in an error: `Cannot read property 'toString' of undefined`.
